### PR TITLE
Removing hint to use ARM

### DIFF
--- a/azure-monitoring/Instructions/1. Monitoring and Alert Rule.md
+++ b/azure-monitoring/Instructions/1. Monitoring and Alert Rule.md
@@ -9,7 +9,6 @@
   * Object: `SQLServer:Databases`
   * Counter: `Active Transactions`
   * Instance: `tpcc`
-  * `Hint:` https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/metrics-store-custom-guestos-resource-manager-vm
 . Download and Install `HammerDB` tool on the `Visual Studio VM` (instructions are in your `Student\Guides\Day-1` folder for setting up and using Hammerdb.
   * www.hammerdb.com
 5. Use `HammerDB` to create transaction load


### PR DESCRIPTION
AZ CLI is the preferred option.